### PR TITLE
Fix condition for finishing challenge validation

### DIFF
--- a/src/FluffySpoon.AspNet.EncryptWeMust/Certes/LetsEncryptClient.cs
+++ b/src/FluffySpoon.AspNet.EncryptWeMust/Certes/LetsEncryptClient.cs
@@ -106,10 +106,10 @@ namespace FluffySpoon.AspNet.EncryptWeMust.Certes
 
             while (true)
             {
-                var anyValid = challenges.Any(x => x.Status == ChallengeStatus.Valid);
-                var allInvalid = challenges.All(x => x.Status == ChallengeStatus.Invalid);
+                var allValid = challenges.All(x => x.Status == ChallengeStatus.Valid);
+                var anyInvalid = challenges.Any(x => x.Status == ChallengeStatus.Invalid);
 				
-                if (anyValid || allInvalid)
+                if (allValid || anyInvalid)
                     break;
                 
                 await Task.Delay(1000);


### PR DESCRIPTION
Fixes #216 

Challenge validation either succeeds when all authorizations (which have one challenge each) are valid, or fails when any are invalid.

I have tested this against a local Pebble instance. When testing without this change, I consistently hit #216, and with the change it works (but only kind of, due to other unrelated issues).

Local testing was fun though. It required modifications to set a custom ACME server, and to bypass validating the server's TLS cert (it's local, so the cert is self-signed). Pebble seems to transition the order to Processing instead of immediately going to Valid (which is quite allowable) which Certes doesn't handle, so update it to the recent beta, and then instead Certes can't find the root / intermediate certificates (for obvious reasons). But Pebble issues the certificate, so everything is working.