### PR TITLE
Add option for selection of desired certificate chain

### DIFF
--- a/src/FluffySpoon.AspNet.EncryptWeMust/Certes/LetsEncryptClient.cs
+++ b/src/FluffySpoon.AspNet.EncryptWeMust/Certes/LetsEncryptClient.cs
@@ -87,7 +87,7 @@ namespace FluffySpoon.AspNet.EncryptWeMust.Certes
 
             var keyPair = KeyFactory.NewKey(_options.KeyAlgorithm);
 			
-            var certificateChain = await order.Generate(_options.CertificateSigningRequest, keyPair);
+            var certificateChain = await order.Generate(_options.CertificateSigningRequest, keyPair, _options.PreferredChain);
 
             var pfxBuilder = certificateChain.ToPfx(keyPair);
 			

--- a/src/FluffySpoon.AspNet.EncryptWeMust/Certes/LetsEncryptOptions.cs
+++ b/src/FluffySpoon.AspNet.EncryptWeMust/Certes/LetsEncryptOptions.cs
@@ -52,6 +52,12 @@ namespace FluffySpoon.AspNet.EncryptWeMust.Certes
 		public KeyAlgorithm KeyAlgorithm { get; set; } = KeyAlgorithm.ES256;
 
 		/// <summary>
+		/// Preferred Chain, when set will define up to which certificate the 
+		/// LetsEncrypt Long Chain: ISRG Root X1
+		/// </summary>
+		public string PreferredChain { get; set; } = "ISRG Root X1";
+
+		/// <summary>
 		/// Get or set a delay before the initial run of the renewal service (subsequent runs will be at 1hr intervals)
 		/// On some platform/deployment systems (e.g Azure Slot Swap) we do not want the renewal service to start immediately, because we may not
 		/// yet have incoming requests (e.g. for challenges) directed to us. 


### PR DESCRIPTION
Since Feb 24 Letsencrypt will be default give back a certificate with the short chain which will fail to validate on old android devices (<=7.0) and will also fail validation on Azure Websites.

A workaround is to request the 'Full chain' by specifying the certificate up to which the chain should be specified in the downloaded certificate.

This PR will add an option to override the PreferredChain parameter of certes, allowing to retrieve the 'full chain' version of the certificate.

https://community.letsencrypt.org/t/long-default-and-short-alternate-certificate-chains-explained/162526