### PR TITLE
Certes 3.0.4 update

### DIFF
--- a/src/FluffySpoon.AspNet.EncryptWeMust.Sample/FluffySpoon.AspNet.EncryptWeMust.Sample.csproj
+++ b/src/FluffySpoon.AspNet.EncryptWeMust.Sample/FluffySpoon.AspNet.EncryptWeMust.Sample.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="bouncycastle" Version="1.8.9" />
-    <PackageReference Include="Certes" Version="3.0.3" />
+    <PackageReference Include="Certes" Version="3.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.Server.WebListener" Version="1.1.4" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />

--- a/src/FluffySpoon.AspNet.EncryptWeMust/Certes/LetsEncryptClient.cs
+++ b/src/FluffySpoon.AspNet.EncryptWeMust/Certes/LetsEncryptClient.cs
@@ -87,7 +87,7 @@ namespace FluffySpoon.AspNet.EncryptWeMust.Certes
 
             var keyPair = KeyFactory.NewKey(_options.KeyAlgorithm);
 			
-            var certificateChain = await order.Generate(_options.CertificateSigningRequest, keyPair, _options.PreferredChain);
+            var certificateChain = await order.Generate(_options.CertificateSigningRequest, keyPair);
 
             var pfxBuilder = certificateChain.ToPfx(keyPair);
 			

--- a/src/FluffySpoon.AspNet.EncryptWeMust/Certes/LetsEncryptOptions.cs
+++ b/src/FluffySpoon.AspNet.EncryptWeMust/Certes/LetsEncryptOptions.cs
@@ -52,12 +52,6 @@ namespace FluffySpoon.AspNet.EncryptWeMust.Certes
 		public KeyAlgorithm KeyAlgorithm { get; set; } = KeyAlgorithm.ES256;
 
 		/// <summary>
-		/// Preferred Chain, when set will define up to which certificate the 
-		/// LetsEncrypt Long Chain: ISRG Root X1
-		/// </summary>
-		public string PreferredChain { get; set; } = "ISRG Root X1";
-
-		/// <summary>
 		/// Get or set a delay before the initial run of the renewal service (subsequent runs will be at 1hr intervals)
 		/// On some platform/deployment systems (e.g Azure Slot Swap) we do not want the renewal service to start immediately, because we may not
 		/// yet have incoming requests (e.g. for challenges) directed to us. 

--- a/src/FluffySpoon.AspNet.EncryptWeMust/FluffySpoon.AspNet.EncryptWeMust.csproj
+++ b/src/FluffySpoon.AspNet.EncryptWeMust/FluffySpoon.AspNet.EncryptWeMust.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="certes" Version="3.0.3" />
+    <PackageReference Include="certes" Version="3.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="6.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.2.0" />


### PR DESCRIPTION
- Updated certes lib to 3.0.4
- PreferredChain from LetsEncryptOptions
- Fix unit tests